### PR TITLE
adding support for logging logback-access events

### DIFF
--- a/logback-ext-aws-core/src/main/java/org/eluder/logback/ext/aws/core/AbstractAwsEncodingStringAppender.java
+++ b/logback-ext-aws-core/src/main/java/org/eluder/logback/ext/aws/core/AbstractAwsEncodingStringAppender.java
@@ -1,5 +1,32 @@
 package org.eluder.logback.ext.aws.core;
 
+/*		
+ * #[license]		
+ * logback-ext-aws-core		
+ * %%		
+ * Copyright (C) 2014 - 2015 Tapio Rautonen		
+ * %%		
+ * Permission is hereby granted, free of charge, to any person obtaining a copy		
+ * of this software and associated documentation files (the "Software"), to deal		
+ * in the Software without restriction, including without limitation the rights		
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell		
+ * copies of the Software, and to permit persons to whom the Software is		
+ * furnished to do so, subject to the following conditions:		
+ * 		
+ * The above copyright notice and this permission notice shall be included in		
+ * all copies or substantial portions of the Software.		
+ * 		
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR		
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,		
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE		
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER		
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,		
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN		
+ * THE SOFTWARE.		
+ * %[license]		
+ */		
+ 
+
 import static java.lang.String.format;
 
 import org.eluder.logback.ext.core.AppenderExecutors;

--- a/logback-ext-aws-core/src/main/java/org/eluder/logback/ext/aws/core/AbstractAwsEncodingStringAppender.java
+++ b/logback-ext-aws-core/src/main/java/org/eluder/logback/ext/aws/core/AbstractAwsEncodingStringAppender.java
@@ -1,46 +1,21 @@
 package org.eluder.logback.ext.aws.core;
 
-/*
- * #[license]
- * logback-ext-aws-core
- * %%
- * Copyright (C) 2014 - 2015 Tapio Rautonen
- * %%
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- * %[license]
- */
+import static java.lang.String.format;
 
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.Context;
-import ch.qos.logback.core.filter.Filter;
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
 import org.eluder.logback.ext.core.AppenderExecutors;
 import org.eluder.logback.ext.core.EncodingStringAppender;
 
-import static java.lang.String.format;
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
 
-public abstract class AbstractAwsEncodingStringAppender<P> extends EncodingStringAppender<ILoggingEvent, P> implements AWSCredentials {
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.filter.Filter;
+
+public abstract class AbstractAwsEncodingStringAppender<E, P> extends EncodingStringAppender<E, P> implements AWSCredentials {
 
     protected final AwsSupport awsSupport;
-    protected final Filter<ILoggingEvent> sdkLoggingFilter;
+    protected final Filter<E> sdkLoggingFilter;
 
     private String accessKey;
     private String secretKey;
@@ -50,10 +25,10 @@ public abstract class AbstractAwsEncodingStringAppender<P> extends EncodingStrin
     private int maxFlushTime = AppenderExecutors.DEFAULT_MAX_FLUSH_TIME;
 
     protected AbstractAwsEncodingStringAppender() {
-        this(new AwsSupport(), new InternalSdkLoggingFilter());
+        this(new AwsSupport(), new InternalSdkLoggingFilter<E>());
     }
 
-    protected AbstractAwsEncodingStringAppender(AwsSupport awsSupport, Filter<ILoggingEvent> sdkLoggingFilter) {
+    protected AbstractAwsEncodingStringAppender(AwsSupport awsSupport, Filter<E> sdkLoggingFilter) {
         this.awsSupport = awsSupport;
         this.sdkLoggingFilter = sdkLoggingFilter;
         addFilter(sdkLoggingFilter);

--- a/logback-ext-aws-core/src/main/java/org/eluder/logback/ext/aws/core/InternalSdkLoggingFilter.java
+++ b/logback-ext-aws-core/src/main/java/org/eluder/logback/ext/aws/core/InternalSdkLoggingFilter.java
@@ -1,53 +1,26 @@
 package org.eluder.logback.ext.aws.core;
 
-/*
- * #[license]
- * logback-ext-aws-core
- * %%
- * Copyright (C) 2014 - 2015 Tapio Rautonen
- * %%
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- * %[license]
- */
-
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.filter.Filter;
 import ch.qos.logback.core.spi.FilterReply;
 
-public class InternalSdkLoggingFilter extends Filter<ILoggingEvent> {
+public class InternalSdkLoggingFilter<E> extends Filter<E> {
 
-    private static final String[] EXCLUDED_PACKAGES = {
-            "org.apache.http.",
-            "com.amazonaws."
-    };
+	private static final String[] EXCLUDED_PACKAGES = { "org.apache.http.", "com.amazonaws." };
 
-    public InternalSdkLoggingFilter() {
-        setName("aws-internal-logging-exclude");
-    }
+	public InternalSdkLoggingFilter() {
+		setName("aws-internal-logging-exclude");
+	}
 
-    @Override
-    public FilterReply decide(ILoggingEvent event) {
-        for (String exclude : EXCLUDED_PACKAGES) {
-            if (event.getLoggerName().startsWith(exclude)) {
-                return FilterReply.DENY;
-            }
-        }
-        return FilterReply.NEUTRAL;
-    }
+	@Override
+	public FilterReply decide(E event) {
+		if (event instanceof ILoggingEvent) {
+			for (String exclude : EXCLUDED_PACKAGES) {
+				if (((ILoggingEvent) event).getLoggerName().startsWith(exclude)) {
+					return FilterReply.DENY;
+				}
+			}
+		}
+		return FilterReply.NEUTRAL;
+	}
 }

--- a/logback-ext-aws-core/src/main/java/org/eluder/logback/ext/aws/core/InternalSdkLoggingFilter.java
+++ b/logback-ext-aws-core/src/main/java/org/eluder/logback/ext/aws/core/InternalSdkLoggingFilter.java
@@ -1,5 +1,31 @@
 package org.eluder.logback.ext.aws.core;
 
+/*
+ * #[license]
+ * logback-ext-aws-core
+ * %%
+ * Copyright (C) 2014 - 2015 Tapio Rautonen
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * %[license]
+ */
+
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.filter.Filter;
 import ch.qos.logback.core.spi.FilterReply;

--- a/logback-ext-core/src/main/java/org/eluder/logback/ext/core/EncodingStringAppender.java
+++ b/logback-ext-core/src/main/java/org/eluder/logback/ext/core/EncodingStringAppender.java
@@ -50,7 +50,7 @@ public abstract class EncodingStringAppender<E, P> extends UnsynchronizedAppende
 
     public final void setCharset(Charset charset) {
         if (encoder instanceof LayoutWrappingEncoder) {
-            ((LayoutWrappingEncoder) encoder).setCharset(charset);
+            ((LayoutWrappingEncoder<E>) encoder).setCharset(charset);
         } else if (encoder instanceof CharacterEncoder) {
             ((CharacterEncoder<?>) encoder).setCharset(charset);
         }

--- a/logback-ext-dynamodb-appender/src/main/java/org/eluder/logback/ext/dynamodb/appender/DynamoDbAppender.java
+++ b/logback-ext-dynamodb-appender/src/main/java/org/eluder/logback/ext/dynamodb/appender/DynamoDbAppender.java
@@ -49,7 +49,7 @@ import java.util.concurrent.CountDownLatch;
 
 import static java.lang.String.format;
 
-public class DynamoDbAppender extends AbstractAwsEncodingStringAppender<String> {
+public class DynamoDbAppender extends AbstractAwsEncodingStringAppender<ILoggingEvent, String> {
 
     private static final String TIMESTAMP_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
     private static final String DEFAULT_PRIMARY_KEY = "Id";

--- a/logback-ext-kinesis-appender/src/main/java/org/eluder/logback/ext/kinesis/appender/AsyncKinesisAppender.java
+++ b/logback-ext-kinesis-appender/src/main/java/org/eluder/logback/ext/kinesis/appender/AsyncKinesisAppender.java
@@ -10,13 +10,13 @@ import java.nio.charset.Charset;
 
 public class AsyncKinesisAppender extends AsyncAppender {
 
-    private final KinesisAppender appender;
+    private final KinesisAppender<ILoggingEvent> appender;
 
     public AsyncKinesisAppender() {
-        this(new KinesisAppender());
+        this(new KinesisAppender<ILoggingEvent>());
     }
 
-    protected AsyncKinesisAppender(KinesisAppender appender) {
+    protected AsyncKinesisAppender(KinesisAppender<ILoggingEvent> appender) {
         appender.setAsyncParent(true);
         addAppender(appender);
         this.appender = appender;

--- a/logback-ext-kinesis-appender/src/main/java/org/eluder/logback/ext/kinesis/appender/KinesisAppender.java
+++ b/logback-ext-kinesis-appender/src/main/java/org/eluder/logback/ext/kinesis/appender/KinesisAppender.java
@@ -1,23 +1,23 @@
 package org.eluder.logback.ext.kinesis.appender;
 
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import com.amazonaws.regions.RegionUtils;
-import com.amazonaws.services.kinesis.AmazonKinesisAsyncClient;
-import com.amazonaws.services.kinesis.model.PutRecordRequest;
-import com.amazonaws.services.kinesis.model.PutRecordResult;
-import com.amazonaws.util.StringUtils;
-import org.eluder.logback.ext.aws.core.AbstractAwsEncodingStringAppender;
-import org.eluder.logback.ext.aws.core.LoggingEventHandler;
-import org.eluder.logback.ext.core.AppenderExecutors;
-import org.eluder.logback.ext.core.ByteArrayPayloadConverter;
+import static java.lang.String.format;
 
 import java.nio.ByteBuffer;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 
-import static java.lang.String.format;
+import org.eluder.logback.ext.aws.core.AbstractAwsEncodingStringAppender;
+import org.eluder.logback.ext.aws.core.LoggingEventHandler;
+import org.eluder.logback.ext.core.AppenderExecutors;
+import org.eluder.logback.ext.core.ByteArrayPayloadConverter;
 
-public class KinesisAppender extends AbstractAwsEncodingStringAppender<byte[]> {
+import com.amazonaws.regions.RegionUtils;
+import com.amazonaws.services.kinesis.AmazonKinesisAsyncClient;
+import com.amazonaws.services.kinesis.model.PutRecordRequest;
+import com.amazonaws.services.kinesis.model.PutRecordResult;
+import com.amazonaws.util.StringUtils;
+
+public class KinesisAppender<E> extends AbstractAwsEncodingStringAppender<E, byte[]> {
 
     private String region;
     private String stream;
@@ -66,7 +66,7 @@ public class KinesisAppender extends AbstractAwsEncodingStringAppender<byte[]> {
     }
 
     @Override
-    protected void handle(ILoggingEvent event, byte[] encoded) throws Exception {
+    protected void handle(E event, byte[] encoded) throws Exception {
         ByteBuffer buffer = ByteBuffer.wrap(encoded);
         PutRecordRequest request = new PutRecordRequest()
                 .withPartitionKey(getPartitionKey(event))
@@ -78,7 +78,7 @@ public class KinesisAppender extends AbstractAwsEncodingStringAppender<byte[]> {
         AppenderExecutors.awaitLatch(this, latch, getMaxFlushTime());
     }
 
-    protected String getPartitionKey(ILoggingEvent event) {
+    protected String getPartitionKey(E event) {
         return UUID.randomUUID().toString();
     }
 }

--- a/logback-ext-sns-appender/src/main/java/org/eluder/logback/ext/sns/appender/SnsAppender.java
+++ b/logback-ext-sns-appender/src/main/java/org/eluder/logback/ext/sns/appender/SnsAppender.java
@@ -2,7 +2,7 @@ package org.eluder.logback.ext.sns.appender;
 
 /*
  * #[license]
- * logback-ext-aws-core
+ * logback-ext-aws-sns-appender
  * %%
  * Copyright (C) 2014 - 2015 Tapio Rautonen
  * %%

--- a/logback-ext-sns-appender/src/main/java/org/eluder/logback/ext/sns/appender/SnsAppender.java
+++ b/logback-ext-sns-appender/src/main/java/org/eluder/logback/ext/sns/appender/SnsAppender.java
@@ -1,5 +1,31 @@
 package org.eluder.logback.ext.sns.appender;
 
+/*
+ * #[license]
+ * logback-ext-aws-core
+ * %%
+ * Copyright (C) 2014 - 2015 Tapio Rautonen
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * %[license]
+ */
+
 import static java.lang.String.format;
 
 import java.util.concurrent.CountDownLatch;

--- a/logback-ext-sns-appender/src/main/java/org/eluder/logback/ext/sns/appender/SnsAppender.java
+++ b/logback-ext-sns-appender/src/main/java/org/eluder/logback/ext/sns/appender/SnsAppender.java
@@ -1,49 +1,24 @@
 package org.eluder.logback.ext.sns.appender;
 
-/*
- * #[license]
- * logback-ext-sns-appender
- * %%
- * Copyright (C) 2014 - 2015 Tapio Rautonen
- * %%
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- * %[license]
- */
-
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.filter.Filter;
-import com.amazonaws.regions.RegionUtils;
-import com.amazonaws.services.sns.AmazonSNSAsyncClient;
-import com.amazonaws.services.sns.model.PublishRequest;
-import com.amazonaws.services.sns.model.PublishResult;
-import org.eluder.logback.ext.aws.core.AbstractAwsEncodingStringAppender;
-import org.eluder.logback.ext.aws.core.AwsSupport;
-import org.eluder.logback.ext.core.AppenderExecutors;
-import org.eluder.logback.ext.aws.core.LoggingEventHandler;
-import org.eluder.logback.ext.core.StringPayloadConverter;
+import static java.lang.String.format;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 
-import static java.lang.String.format;
+import org.eluder.logback.ext.aws.core.AbstractAwsEncodingStringAppender;
+import org.eluder.logback.ext.aws.core.AwsSupport;
+import org.eluder.logback.ext.aws.core.LoggingEventHandler;
+import org.eluder.logback.ext.core.AppenderExecutors;
+import org.eluder.logback.ext.core.StringPayloadConverter;
 
-public class SnsAppender extends AbstractAwsEncodingStringAppender<String> {
+import com.amazonaws.regions.RegionUtils;
+import com.amazonaws.services.sns.AmazonSNSAsyncClient;
+import com.amazonaws.services.sns.model.PublishRequest;
+import com.amazonaws.services.sns.model.PublishResult;
+
+import ch.qos.logback.core.filter.Filter;
+
+public class SnsAppender<E> extends AbstractAwsEncodingStringAppender<E, String> {
 
     private String region;
     private String topic;
@@ -55,7 +30,7 @@ public class SnsAppender extends AbstractAwsEncodingStringAppender<String> {
         super();
     }
 
-    protected SnsAppender(AwsSupport awsSupport, Filter<ILoggingEvent> sdkLoggingFilter) {
+    protected SnsAppender(AwsSupport awsSupport, Filter<E> sdkLoggingFilter) {
         super(awsSupport, sdkLoggingFilter);
     }
 
@@ -97,7 +72,7 @@ public class SnsAppender extends AbstractAwsEncodingStringAppender<String> {
     }
 
     @Override
-    protected void handle(final ILoggingEvent event, final String encoded) throws Exception {
+    protected void handle(final E event, final String encoded) throws Exception {
         PublishRequest request = new PublishRequest(topic, encoded, subject);
         String errorMessage = format("Appender '%s' failed to send logging event '%s' to SNS topic '%s'", getName(), event, topic);
         CountDownLatch latch = new CountDownLatch(isAsyncParent() ? 0 : 1);

--- a/logback-ext-sns-appender/src/main/java/org/eluder/logback/ext/sns/appender/SnsAppender.java
+++ b/logback-ext-sns-appender/src/main/java/org/eluder/logback/ext/sns/appender/SnsAppender.java
@@ -2,7 +2,7 @@ package org.eluder.logback.ext.sns.appender;
 
 /*
  * #[license]
- * logback-ext-aws-sns-appender
+ * logback-ext-sns-appender
  * %%
  * Copyright (C) 2014 - 2015 Tapio Rautonen
  * %%

--- a/logback-ext-sqs-appender/src/main/java/org/eluder/logback/ext/sqs/appender/SqsAppender.java
+++ b/logback-ext-sqs-appender/src/main/java/org/eluder/logback/ext/sqs/appender/SqsAppender.java
@@ -1,50 +1,25 @@
 package org.eluder.logback.ext.sqs.appender;
 
-/*
- * #[license]
- * logback-ext-sqs-appender
- * %%
- * Copyright (C) 2014 - 2015 Tapio Rautonen
- * %%
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- * %[license]
- */
-
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.filter.Filter;
-import com.amazonaws.services.sqs.AmazonSQSAsyncClient;
-import com.amazonaws.services.sqs.model.SendMessageRequest;
-import com.amazonaws.services.sqs.model.SendMessageResult;
-import org.eluder.logback.ext.aws.core.AbstractAwsEncodingStringAppender;
-import org.eluder.logback.ext.aws.core.AwsSupport;
-import org.eluder.logback.ext.aws.core.LoggingEventHandler;
-import org.eluder.logback.ext.core.AppenderExecutors;
-import org.eluder.logback.ext.core.StringPayloadConverter;
+import static java.lang.String.format;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 
-import static java.lang.String.format;
+import org.eluder.logback.ext.aws.core.AbstractAwsEncodingStringAppender;
+import org.eluder.logback.ext.aws.core.AwsSupport;
+import org.eluder.logback.ext.aws.core.LoggingEventHandler;
+import org.eluder.logback.ext.core.AppenderExecutors;
+import org.eluder.logback.ext.core.StringPayloadConverter;
 
-public class SqsAppender extends AbstractAwsEncodingStringAppender<String> {
+import com.amazonaws.services.sqs.AmazonSQSAsyncClient;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
+import com.amazonaws.services.sqs.model.SendMessageResult;
+
+import ch.qos.logback.core.filter.Filter;
+
+public class SqsAppender<E> extends AbstractAwsEncodingStringAppender<E, String> {
 
     private String queueUrl;
 
@@ -54,7 +29,7 @@ public class SqsAppender extends AbstractAwsEncodingStringAppender<String> {
         super();
     }
 
-    protected SqsAppender(AwsSupport awsSupport, Filter<ILoggingEvent> sdkLoggingFilter) {
+    protected SqsAppender(AwsSupport awsSupport, Filter<E> sdkLoggingFilter) {
         super(awsSupport, sdkLoggingFilter);
     }
 
@@ -100,7 +75,7 @@ public class SqsAppender extends AbstractAwsEncodingStringAppender<String> {
     }
 
     @Override
-    protected void handle(final ILoggingEvent event, final String encoded) throws Exception {
+    protected void handle(final E event, final String encoded) throws Exception {
         SendMessageRequest request = new SendMessageRequest(queueUrl, encoded);
         String errorMessage = format("Appender '%s' failed to send logging event '%s' to SQS queue '%s'", getName(), event, queueUrl);
         CountDownLatch latch = new CountDownLatch(isAsyncParent() ? 0 : 1);

--- a/logback-ext-sqs-appender/src/main/java/org/eluder/logback/ext/sqs/appender/SqsAppender.java
+++ b/logback-ext-sqs-appender/src/main/java/org/eluder/logback/ext/sqs/appender/SqsAppender.java
@@ -1,5 +1,31 @@
 package org.eluder.logback.ext.sqs.appender;
 
+/*
+ * #[license]
+ * logback-ext-aws-core
+ * %%
+ * Copyright (C) 2014 - 2015 Tapio Rautonen
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * %[license]
+ */
+
 import static java.lang.String.format;
 
 import java.net.URI;

--- a/logback-ext-sqs-appender/src/main/java/org/eluder/logback/ext/sqs/appender/SqsAppender.java
+++ b/logback-ext-sqs-appender/src/main/java/org/eluder/logback/ext/sqs/appender/SqsAppender.java
@@ -2,7 +2,7 @@ package org.eluder.logback.ext.sqs.appender;
 
 /*
  * #[license]
- * logback-ext-aws-appender
+ * logback-ext-sqs-appender
  * %%
  * Copyright (C) 2014 - 2015 Tapio Rautonen
  * %%

--- a/logback-ext-sqs-appender/src/main/java/org/eluder/logback/ext/sqs/appender/SqsAppender.java
+++ b/logback-ext-sqs-appender/src/main/java/org/eluder/logback/ext/sqs/appender/SqsAppender.java
@@ -2,7 +2,7 @@ package org.eluder.logback.ext.sqs.appender;
 
 /*
  * #[license]
- * logback-ext-aws-core
+ * logback-ext-aws-appender
  * %%
  * Copyright (C) 2014 - 2015 Tapio Rautonen
  * %%


### PR DESCRIPTION
This patch 'genericizes' the appender classes (except for the dynamodb appender) to allow logback-access to use the appenders to log HTTP requests.    I left the dynamodb and async kinesis appenders alone as they seemed to be very tied to ILoggingEvent.

The one change that is a bit ugly is the use of introspection in CloudWatchAppender.handle() to get the timestamp for the event.  Both ILoggingEvent and IAccessEvent have a getTimeStamp() method so the introspection works for both 'regular' logback and logback access (if only both of these interfaces inherited from a common parent interface...)

Unfortunately Eclipse rearranged a lot of the imports so there are a bunch of spurious changes as well. 

I tested the changes and could successfully post 'regular' logback events and logback access logs via tomcat to AWS cloudwatch.   