### PR TITLE
#7 Update AWS version to 1.11.5, change SNAPSHOT version to 1.1 

### DIFF
--- a/logback-ext-aws-core/pom.xml
+++ b/logback-ext-aws-core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eluder.logback</groupId>
     <artifactId>logback-ext</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>logback-ext-aws-core</artifactId>

--- a/logback-ext-cloudwatch-appender/pom.xml
+++ b/logback-ext-cloudwatch-appender/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eluder.logback</groupId>
     <artifactId>logback-ext</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>logback-ext-cloudwatch-appender</artifactId>

--- a/logback-ext-core/pom.xml
+++ b/logback-ext-core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>logback-ext</artifactId>
     <groupId>org.eluder.logback</groupId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
   </parent>
   
   <artifactId>logback-ext-core</artifactId>

--- a/logback-ext-dynamodb-appender/pom.xml
+++ b/logback-ext-dynamodb-appender/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>logback-ext</artifactId>
     <groupId>org.eluder.logback</groupId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>logback-ext-dynamodb-appender</artifactId>

--- a/logback-ext-jackson/pom.xml
+++ b/logback-ext-jackson/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>logback-ext</artifactId>
     <groupId>org.eluder.logback</groupId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
   </parent>
   
   <artifactId>logback-ext-jackson</artifactId>

--- a/logback-ext-kinesis-appender/pom.xml
+++ b/logback-ext-kinesis-appender/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eluder.logback</groupId>
     <artifactId>logback-ext</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>logback-ext-kinesis-appender</artifactId>

--- a/logback-ext-lmax-appender/pom.xml
+++ b/logback-ext-lmax-appender/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>logback-ext</artifactId>
     <groupId>org.eluder.logback</groupId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>logback-ext-lmax-appender</artifactId>

--- a/logback-ext-sns-appender/pom.xml
+++ b/logback-ext-sns-appender/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>logback-ext</artifactId>
     <groupId>org.eluder.logback</groupId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>logback-ext-sns-appender</artifactId>

--- a/logback-ext-sqs-appender/pom.xml
+++ b/logback-ext-sqs-appender/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>logback-ext</artifactId>
     <groupId>org.eluder.logback</groupId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>logback-ext-sqs-appender</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.eluder.logback</groupId>
   <artifactId>logback-ext</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>logback-ext</name>
@@ -45,7 +45,7 @@
     <java.version>1.7</java.version>
     <guava.version>18.0</guava.version>
     <jackson.version>2.5.4</jackson.version>
-    <aws.version>1.10.2</aws.version>
+    <aws.version>1.11.5</aws.version>
     <lmax.version>3.3.2</lmax.version>
     <jmh.version>1.10.5</jmh.version>
   </properties>


### PR DESCRIPTION
Updated SNAPSHOT version since this is a backwards incompatible change for users with a pre-1.11.x AWS version.
